### PR TITLE
ci: rename CI task name to "Continuous Integration"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration Tests
+name: Continuous Integration
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the name of the CI workflow from 'Continuous Integration Tests' to 'Continuous Integration'