### PR TITLE
ci: only run CI checks when the target branch of push/PR is `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
 name: Continuous Integration
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update GitHub Actions workflow to limit CI checks to pushes and pull requests targeting the main branch