### PR TITLE
ci: allow running `pre-commit-auto-update` on demand via manual dispatch

### DIFF
--- a/.github/workflows/pre-commit-auto-update.yaml
+++ b/.github/workflows/pre-commit-auto-update.yaml
@@ -4,6 +4,8 @@ on:
   # every day at midnight
   schedule:
   - cron: 0 0 * * *
+  # on demand
+  workflow_dispatch:
 
 jobs:
   pre-commit-auto-update:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Enable manual triggering of the pre-commit auto-update workflow via GitHub Actions workflow dispatch