### PR TITLE
chore: allow using `.env` files for storing secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,9 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
+.envrc
 .env
+.env.*
 .venv
 env/
 venv/
@@ -145,6 +147,4 @@ cases/
 sandbox/
 *.vscode/
 
-!tox.ini
-.envrc
 __pypackages__


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Configure .gitignore to exclude .env files from version control