### PR TITLE
docs(README): fix CI badge to use the correct CI workflow file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Boiling Learning
 [![Code style: Ruff](https://img.shields.io/badge/Ruff-checked-261230.svg?logo=ruff)](https://docs.astral.sh/ruff/)
 [![Sourcery](https://img.shields.io/badge/Sourcery-enabled-brightgreen)](https://sourcery.ai)
 
-[![Github Actions](https://github.com/commitizen-tools/commitizen/workflows/Python%20package/badge.svg?style=flat-square)](https://github.com/ruancomelli/boiling-learning/actions)
+[![CI](https://github.com/ruancomelli/boiling-learning/actions/workflows/ci.yaml/badge.svg)](https://github.com/ruancomelli/boiling-learning/actions/workflows/ci.yaml)
 [![SemVer](https://img.shields.io/badge/semver-2.0.0-green)](https://semver.org/spec/v2.0.0.html)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![Author: ruancomelli](https://img.shields.io/badge/ruancomelli-blue?style=flat&label=author)](https://github.com/ruancomelli)


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace the generic GitHub Actions badge with a specific badge for the project's CI workflow